### PR TITLE
dataset: remove unused interface

### DIFF
--- a/src/dataset/types/index.ts
+++ b/src/dataset/types/index.ts
@@ -56,11 +56,6 @@ export interface ImageDimension {
   z: number
 }
 
-export interface BaseDatasetMeta {
-  type: DatasetType;
-  size: DatasetSize;
-}
-
 export interface DatasetMeta {
   type: DatasetType;
   size: DatasetSize;

--- a/src/dataset/types/index.ts
+++ b/src/dataset/types/index.ts
@@ -56,9 +56,12 @@ export interface ImageDimension {
   z: number
 }
 
-export interface DatasetMeta {
+export interface BaseDatasetMeta {
   type: DatasetType;
   size: DatasetSize;
+}
+
+export interface DatasetMeta extends BaseDatasetMeta {
   labelMap: Record<number, any>;
 }
 


### PR DESCRIPTION
I searched the datacook and pipcook projects, and removed it because of useless.