### PR TITLE
upgrade tfjs version to newer one

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@pipcook/datacook",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "A JavaScript library for feature engineering on datasets",
   "main": "dist/index.js",
   "dependencies": {
-    "@tensorflow/tfjs-backend-cpu": "^2.7.0",
-    "@tensorflow/tfjs-backend-wasm": "^2.7.0",
-    "@tensorflow/tfjs-core": "^2.7.0",
-    "@tensorflow/tfjs-layers": "^2.8.0",
+    "@tensorflow/tfjs-backend-cpu": "^3.8.0",
+    "@tensorflow/tfjs-backend-wasm": "^3.8.0",
+    "@tensorflow/tfjs-core": "^3.8.0",
+    "@tensorflow/tfjs-layers": "^3.8.0",
     "buffer": "^6.0.3",
     "cross-fetch": "^3.1.2",
     "jimp": "^0.16.1",
@@ -26,7 +26,6 @@
     "coveralls": "cat ./coverage/lcov.info | ./node_modules/.bin/coveralls",
     "coverage": "nyc report --reporter=text-lcov | coveralls && nyc report --reporter=lcov",
     "patch": "npm version patch",
-    "publish": "npm pack && npm publish",
     "doc": "typedoc src/index.ts --name \"Datacook API\" --out ./doc --tsconfig ./tsconfig.ts --highlightTheme github-light"
   },
   "repository": {

--- a/src/generic/index.ts
+++ b/src/generic/index.ts
@@ -1,4 +1,4 @@
-import { Tensor } from '@tensorflow/tfjs-core';
+import { Tensor, split as splitOp } from '@tensorflow/tfjs-core';
 import 'seedrandom';
 
 function seed(seed: string): void {
@@ -28,7 +28,7 @@ function split(inputs: Tensor[], trainRatio = .75): Tensor[]{
   const trainSize = Math.floor(size * trainRatio);
   const testSize = size - trainSize;
 
-  const results = inputs.map((input) => input.split([ trainSize, testSize ])).reduce((prev, curr) => {
+  const results = inputs.map((input) => splitOp(input, [ trainSize, testSize ])).reduce((prev, curr) => {
     prev.push(...curr);
     return prev;
   }, []);

--- a/src/image/index.ts
+++ b/src/image/index.ts
@@ -134,11 +134,9 @@ export class Image {
    * @return Tensor3D
    */
   static normalize(data: tf.Tensor3D, mean?: number, std?:number): tf.Tensor3D {
-
-    const tfMean = mean ? mean : data.mean().round().arraySync();
+    const tfMean = mean ? mean : tf.round(tf.mean(data)).arraySync();
     const tfStd = std ? std : stdCalc(data);
-    const norm = data.sub(tfMean).div(tfStd);
-
+    const norm = tf.div(tf.sub(data, tfMean), tfStd);
     return norm as tf.Tensor3D;
   }
 
@@ -150,7 +148,7 @@ export class Image {
    * @returns Tensor
    */
   static unnormalize(data: tf.Tensor3D, mean: number, std:number): tf.Tensor3D {
-    const unnorm = tf.cast(data.mul(std).add(mean), "int32");
+    const unnorm = tf.cast(tf.add(tf.mul(data, std), mean), 'int32');
     return unnorm as tf.Tensor3D;
   }
 

--- a/src/image/utils.ts
+++ b/src/image/utils.ts
@@ -1,6 +1,5 @@
 import * as tf from '@tensorflow/tfjs-core';
 
 export function stdCalc(data: tf.Tensor3D): number {
-
-  return tf.moments(data).variance.sqrt().round().arraySync() as number;
+  return tf.round(tf.sqrt(tf.moments(data).variance)).arraySync() as number;
 }

--- a/src/text/word2vec.ts
+++ b/src/text/word2vec.ts
@@ -1,6 +1,6 @@
 import * as tf from '@tensorflow/tfjs-layers';
 import { createData, createUniqueWord, objectLength, skipGram, UniqueWord } from './word2vec-utils';
-import { tensor } from '@tensorflow/tfjs-core';
+import { tensor, sub, pow, mean, sqrt } from '@tensorflow/tfjs-core';
 
 export default class Word2Vec {
   public weight: number[][] | undefined = undefined;
@@ -70,7 +70,7 @@ export default class Word2Vec {
     const indexB = this.uniqueWords[wordB];
     const weightA = tensor(this.weight[indexA]);
     const weightB = tensor(this.weight[indexB]);
-    const sim = weightA.sub(weightB).pow(2).mean().sqrt();
+    const sim = sqrt(mean(pow(sub(weightA, weightB), 2)));
     return sim.arraySync() as number;
 
   }
@@ -99,7 +99,7 @@ export default class Word2Vec {
     const wordWeight = tensor(this.weight[index]);
     weight.splice(index - 1, 1);
 
-    const rslt = tensor(weight).sub(wordWeight).pow(2).mean(1).sqrt();
+    const rslt = sqrt(mean(pow(sub(tensor(weight), wordWeight), 2), 1));
     const simArray = rslt.arraySync() as number[];
 
     let similarities = Object.keys(this.uniqueWords);

--- a/test/node/generic/index.ts
+++ b/test/node/generic/index.ts
@@ -17,17 +17,17 @@ describe('Generic Split test',
        *   [8, 9]
        * ]
        */
-      const X = tf.range(0, 10).reshape([5, 2]);
+      const X = tf.reshape(tf.range(0, 10), [5, 2]);
       
       const y = tf.range(0, 5);
 
       const [X_train, X_test, y_train, y_test] = split([X, y]); 
       
-      const actX_test = tf.range(6, 10).reshape([2, 2]);
-      const actX_train = tf.range(0, 6).reshape([3, 2]);
+      const actX_test = tf.reshape(tf.range(6, 10), [2, 2]);
+      const actX_train = tf.reshape(tf.range(0, 6), [3, 2]);
       
-      const acty_train = tf.range(0, 3).reshape([3]);
-      const acty_test = tf.range(3, 5).reshape([2]);
+      const acty_train = tf.reshape(tf.range(0, 3), [3]);
+      const acty_test = tf.reshape(tf.range(3, 5), [2]);
 
       expect(actX_test.dataSync()).to.eql(X_test.dataSync());
       expect(actX_train.dataSync()).to.eql(X_train.dataSync());

--- a/test/node/image/image-proc.ts
+++ b/test/node/image/image-proc.ts
@@ -2,6 +2,7 @@ import { assert, expect } from "chai"
 import {Image} from "../../../src/image";
 import {stdCalc} from "../../../src/image/utils";
 import * as fs from 'fs';
+import * as tf from '@tensorflow/tfjs-core';
 import '@tensorflow/tfjs-backend-cpu';
 
 describe("Image-proc", ()=>{
@@ -62,7 +63,7 @@ describe("Image-proc", ()=>{
 
     const resizeTensor = img.resize(50,50).toTensor();
     const img2: Image = await Image.fromTensor(resizeTensor);
-    const mean = resizeTensor.mean().round().arraySync() as number;
+    const mean = tf.round(tf.mean(resizeTensor)).arraySync() as number;
     const std = stdCalc(resizeTensor);
     
     const normalize = Image.normalize(resizeTensor);


### PR DESCRIPTION
Currently datacook relies on an old version of tfjs and some of operators are not supported. This PR is to upgrade into newer version. 