### PR TITLE
utils: add tidyAsync() which allows the fn to return a Promise.

### DIFF
--- a/src/utils/memory.ts
+++ b/src/utils/memory.ts
@@ -1,0 +1,28 @@
+import { ENV, TensorContainer } from '@tensorflow/tfjs-core';
+
+/**
+ * FIXME(Yorkie): is there a better way to access tfengine instance from tfjs-core?
+ */
+const engine = ENV.global._tfengine;
+
+/**
+ * The tidy-like method that supports Promise, we still recommend you to use tidy() directly and
+ * avoid asynchronous operations.
+ *
+ * See https://github.com/tensorflow/tfjs/commit/5acd02003c3a00256f495ced52a0c1c85bde52fc.
+ */
+export async function tidyAsync<T extends TensorContainer>(fn: () => Promise<T>) {
+  engine.startScope();
+  let result: T;
+  const end = () => engine.endScope(result);
+
+  try {
+    result = await fn();
+    end();
+    return result;
+  } catch (err) {
+    end();
+    throw err;
+  }
+}
+

--- a/src/utils/memory.ts
+++ b/src/utils/memory.ts
@@ -6,15 +6,32 @@ import { ENV, TensorContainer } from '@tensorflow/tfjs-core';
 const engine = ENV.global._tfengine;
 
 /**
+ * `tidy()` depends on engine's scoped runner, unfortunately the engine is singleton
+ * and it doesn't support named scope, the tidy have to implement it in singleton.
+ *
+ * TODO(Yorkie): help tfjs to implement named scope, then we could remove this state.
+ */
+let isAsynchronousTidyRunning = false;
+
+/**
  * The tidy-like method that supports Promise, we still recommend you to use tidy() directly and
- * avoid asynchronous operations.
+ * avoid asynchronous operations. In addition, you need to pay attention to it when you use it,
+ * you must ensure that only 1 tidy is running globally.
  *
  * See https://github.com/tensorflow/tfjs/commit/5acd02003c3a00256f495ced52a0c1c85bde52fc.
  */
 export async function tidyAsync<T extends TensorContainer>(fn: () => Promise<T>): Promise<T> {
+  if (isAsynchronousTidyRunning === true) {
+    throw new TypeError('tidy must have only 1 running instance, please create a new tidy after others end.');
+  }
   engine.startScope();
+  isAsynchronousTidyRunning = true;
+
   let result: T;
-  const end = () => engine.endScope(result);
+  const end = () => {
+    engine.endScope(result);
+    isAsynchronousTidyRunning = false;
+  };
 
   try {
     result = await fn();

--- a/src/utils/memory.ts
+++ b/src/utils/memory.ts
@@ -11,7 +11,7 @@ const engine = ENV.global._tfengine;
  *
  * See https://github.com/tensorflow/tfjs/commit/5acd02003c3a00256f495ced52a0c1c85bde52fc.
  */
-export async function tidyAsync<T extends TensorContainer>(fn: () => Promise<T>) {
+export async function tidyAsync<T extends TensorContainer>(fn: () => Promise<T>): Promise<T> {
   engine.startScope();
   let result: T;
   const end = () => engine.endScope(result);

--- a/test/node/utils/memory.ts
+++ b/test/node/utils/memory.ts
@@ -1,0 +1,44 @@
+import { tidyAsync } from '../../../src/utils/memory';
+import { tensor1d, memory } from '@tensorflow/tfjs-core';
+import { assert } from 'chai';
+
+describe('utils', function () {
+  it('creates a tidy and check if Promise is supported.', () => {
+    tidyAsync(() => {
+      return new Promise<number>((resolve) => setTimeout(resolve.bind(null, 1), 500));
+    });
+  });
+
+  it('adds an async ops to a created tidy and check its memory management.', async () => {
+    const tensorBase = memory().numTensors;
+    const bytesBase = memory().numBytes;
+    console.log('the before memory info is', tensorBase, bytesBase);
+    await tidyAsync(async () => {
+      const a = tensor1d([1, 2, 3, 4]);
+      const b = tensor1d([2, 3, 4, 5]);
+      await a.data();
+      await b.data();
+      assert.equal(memory().numTensors, tensorBase + 2);
+      assert.equal(memory().numBytes, bytesBase + 32);
+    });
+    assert.equal(memory().numTensors, tensorBase);
+    assert.equal(memory().numBytes, bytesBase);
+  });
+
+  it('adds an async ops with exceptions and check its memory management', async () => {
+    const tensorBase = memory().numTensors;
+    try {
+      await tidyAsync(async () => {
+        tensor1d([0, 4, 2, 2]);
+        tensor1d([0, 4, 2, 3]);
+        assert.equal(memory().numTensors, tensorBase + 2);
+        throw new TypeError('this is an exception.');
+        assert.fail('should not be reachable');
+      });
+    } catch (err) {
+      assert.equal(err.message, 'this is an exception.');
+    }
+    assert.equal(memory().numTensors, tensorBase);
+  });
+});
+

--- a/test/node/utils/memory.ts
+++ b/test/node/utils/memory.ts
@@ -1,10 +1,10 @@
-import { tidyAsync } from '../../../src/utils/memory';
 import { tensor1d, memory } from '@tensorflow/tfjs-core';
 import { assert } from 'chai';
+import { tidyAsync } from '../../../src/utils/memory';
 
 describe('utils', function () {
-  it('creates a tidy and check if Promise is supported.', () => {
-    tidyAsync(() => {
+  it('creates a tidy and check if Promise is supported.', async () => {
+    await tidyAsync(() => {
       return new Promise<number>((resolve) => setTimeout(resolve.bind(null, 1), 500));
     });
   });
@@ -39,6 +39,22 @@ describe('utils', function () {
       assert.equal(err.message, 'this is an exception.');
     }
     assert.equal(memory().numTensors, tensorBase);
+  });
+
+  it('adds multiple calls to tidy, and got an error when first not ended', async () => {
+    tidyAsync(async () => {
+      return new Promise<number>((resolve) => setTimeout(resolve.bind(null, 1), 500)); 
+    });
+
+    let caughtError = false;
+    try {
+      await tidyAsync(async () => tensor1d([0]));
+    } catch (err) {
+      assert.equal(err.message,
+        'tidy must have only 1 running instance, please create a new tidy after others end.');
+      caughtError = true;
+    }
+    assert.equal(caughtError, true);
   });
 });
 


### PR DESCRIPTION
The `tidy()` function disallow async function, which makes memory management with some asynchronous operations not too friendly.

But we still have to use this method with caution, because tfjs has also been implemented before, but it was later disabled in the following commit: https://github.com/tensorflow/tfjs/commit/5acd02003c3a00256f495ced52a0c1c85bde52fc.